### PR TITLE
Refine component styling and collapse consecutive figure/table borders

### DIFF
--- a/src/components/CollectionList.js
+++ b/src/components/CollectionList.js
@@ -20,8 +20,8 @@ export default function CollectionList({
   showExpandAll = false,
 
   /* ── STACK styles ─────────────────────────────────── */
-  boxExpandableClass = 'bg-white dark:bg-[#1e2224] border border-border-color border-l-[3px] border-l-ifm-primary rounded-lg px-3 py-2.5 hover:border-l-ifm-primary-dark hover:shadow-sm transition',
-  boxStaticClass = 'bg-white dark:bg-[#1e2224] border border-border-color rounded-lg px-3 py-2.5',
+  boxExpandableClass = 'bg-[#e8eef0] dark:bg-[#2e373b] border border-border-color border-l-[3px] border-l-ifm-primary rounded-lg px-3 py-2.5 hover:border-l-ifm-primary-dark hover:shadow-sm transition',
+  boxStaticClass = 'bg-[#e8eef0] dark:bg-[#2e373b] border border-border-color rounded-lg px-3 py-2.5',
   badgeClass = 'bg-ifm-primary rounded-full shadow text-caption font-usace text-font-color-inverse',
   fontClass = 'font-usace text-normal text-font-color',
   panelClass = 'prose max-w-none rounded-b-lg border-t border-border-color bg-[#f8fafa] dark:bg-[#161a1c] text-font-color mt-3 px-3 py-2.5',
@@ -36,8 +36,8 @@ export default function CollectionList({
 
   gridWrapperClass = 'grid gap-3 w-full',
   gridColsOverrideClass = '',
-  gridTileExpandableClass = 'bg-white dark:bg-[#1e2224] border border-border-color border-t-[3px] border-t-ifm-primary rounded-lg px-3 py-2.5 hover:border-t-ifm-primary-dark hover:shadow-sm transition',
-  gridTileStaticClass = 'bg-white dark:bg-[#1e2224] border border-border-color rounded-lg px-3 py-2.5',
+  gridTileExpandableClass = 'bg-[#e8eef0] dark:bg-[#2e373b] border border-border-color border-t-[3px] border-t-ifm-primary rounded-lg px-3 py-2.5 hover:border-t-ifm-primary-dark hover:shadow-sm transition',
+  gridTileStaticClass = 'bg-[#e8eef0] dark:bg-[#2e373b] border border-border-color rounded-lg px-3 py-2.5',
 
   gridHeaderButtonClass = 'grid w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-ifm-primary/40 rounded-md grid-cols-[1fr_auto_1fr] items-center',
   gridHeaderDisabledClass = 'grid w-full grid-cols-[1fr_auto_1fr] items-center',

--- a/src/components/ProcessList.js
+++ b/src/components/ProcessList.js
@@ -123,27 +123,47 @@ export default function ProcessList({
                 ) : numberStyle === 'chevron' ? (
                   <span
                     aria-hidden="true"
-                    className={`inline-flex items-center justify-center ${fontClass} ${lineHeightClass} bg-ifm-primary text-font-color-inverse shadow`}
+                    className={fontClass}
                     style={{
-                      width: Math.round(bubbleSizePx * 1.1),
-                      height: bubbleSizePx,
-                      clipPath: 'polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%)',
-                      marginTop: `max(0px, calc((1.5em - ${bubbleSizePx}px) / 2))`,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      height: '1.5em',
                     }}
                   >
-                    {n}
+                    <span
+                      className={`inline-flex items-center justify-center ${fontClass} ${lineHeightClass} bg-ifm-primary text-font-color-inverse shadow`}
+                      style={{
+                        width: Math.round(bubbleSizePx * 1.1),
+                        height: bubbleSizePx,
+                        clipPath: 'polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%)',
+                        flexShrink: 0,
+                      }}
+                    >
+                      {n}
+                    </span>
                   </span>
                 ) : (
                   <span
                     aria-hidden="true"
-                    className={`inline-flex items-center justify-center ${badgeClass}`}
+                    className={fontClass}
                     style={{
-                      width: bubbleSizePx,
-                      height: bubbleSizePx,
-                      marginTop: `max(0px, calc((1.5em - ${bubbleSizePx}px) / 2))`,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      height: '1.5em',
                     }}
                   >
-                    {n}
+                    <span
+                      className={`inline-flex items-center justify-center ${badgeClass}`}
+                      style={{
+                        width: bubbleSizePx,
+                        height: bubbleSizePx,
+                        flexShrink: 0,
+                      }}
+                    >
+                      {n}
+                    </span>
                   </span>
                 )}
                 <span aria-hidden="true" />
@@ -293,14 +313,24 @@ function ChildGroup({
               ) : (
                 <span
                   aria-hidden="true"
-                  className={`inline-flex items-center justify-center ${badgeClass}`}
+                  className={fontClass}
                   style={{
-                    width: bubbleSizePx,
-                    height: bubbleSizePx,
-                    marginTop: `max(0px, calc((1.5em - ${bubbleSizePx}px) / 2))`,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '1.5em',
                   }}
                 >
-                  {label}
+                  <span
+                    className={`inline-flex items-center justify-center ${badgeClass}`}
+                    style={{
+                      width: bubbleSizePx,
+                      height: bubbleSizePx,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {label}
+                  </span>
                 </span>
               )}
               <span aria-hidden="true" />

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -477,10 +477,21 @@ html[data-theme='dark'] .DocSearch-Button {
 }
 
 /* Collapse redundant borders between consecutive figures and/or tables */
+/* Remove bottom border from the first element when followed by another */
+figure:has(+ figure),
+figure:has(+ .table-container),
+.table-container:has(+ figure),
+.table-container:has(+ .table-container) {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin-bottom: 0;
+}
+/* Remove top border from the second element */
 figure + figure,
 .table-container + .table-container,
 figure + .table-container,
 .table-container + figure {
   border-top: none;
+  padding-top: 0;
   margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- Eliminates all intermediate border lines between consecutive `<figure>` and `.table-container` elements using `:has()` CSS selectors to remove the bottom border from the first element and the top border from the second
- Updates CollectionList tile background colors for improved contrast in both light and dark themes
- Wraps ProcessList number badges (circle and chevron) in centering containers for proper vertical alignment