### PR TITLE
Populate all GA4 custom dimensions to eliminate (not set) in analytics

### DIFF
--- a/src/clientModules/analyticsEvents.js
+++ b/src/clientModules/analyticsEvents.js
@@ -34,17 +34,20 @@ if (typeof window !== 'undefined') {
 function parsePath(pathname) {
   const path = pathname.startsWith(BASE_PATH) ? pathname.slice(BASE_PATH.length).replace(/\/$/, '') : pathname.replace(/^\//, '').replace(/\/$/, '');
 
-  // Home page
+  // Site-wide pages — all dimensions carry the page name
   if (!path) {
-    return { page_type: 'home' };
+    return { page_type: 'home', doc_category: 'home', doc_product: 'home', doc_type: 'home', doc_version: 'home', doc_page: 'home', doc_path: 'home' };
   }
 
-  // Changelog
   if (path === 'changelog') {
-    return { page_type: 'changelog' };
+    return { page_type: 'changelog', doc_category: 'changelog', doc_product: 'changelog', doc_type: 'changelog', doc_version: 'changelog', doc_page: 'changelog', doc_path: 'changelog' };
   }
 
-  // Documentation pages: docs/{category}/{product}/{doc_type}/v{X}.{Y}/{page}
+  if (path === 'feedback') {
+    return { page_type: 'feedback', doc_category: 'feedback', doc_product: 'feedback', doc_type: 'feedback', doc_version: 'feedback', doc_page: 'feedback', doc_path: 'feedback' };
+  }
+
+  // Versioned documentation pages: docs/{category}/{product}/{doc_type}/v{X}.{Y}/{page}
   if (path.startsWith('docs/')) {
     const segments = path.replace(/^docs\//, '').split('/');
     const versionIdx = segments.findIndex((s) => /^v\d+\.\d+/.test(s));
@@ -57,7 +60,6 @@ function parsePath(pathname) {
       const doc_page = segments.slice(versionIdx + 1).join('/') || '(index)';
       const doc_path = segments.slice(0, versionIdx + 1).join('/');
 
-      // Lookup key for latestVersions.json: everything before the version
       const lookupKey = segments.slice(0, versionIdx).join('/');
       const latest = latestVersions?.[lookupKey];
       const is_latest_version = latest ? (latest === doc_version ? 'true' : 'false') : 'unknown';
@@ -65,10 +67,36 @@ function parsePath(pathname) {
       return { page_type: 'doc_page', doc_category: category, doc_product: product, doc_type, doc_version, doc_page, doc_path, is_latest_version };
     }
 
-    return { page_type: 'docs_index' };
+    // Dev docs: docs/dev/{product...}/{page} — no version segment
+    if (segments[0] === 'dev' && segments.length >= 2) {
+      const product = segments.slice(1, -1).join('/') || segments[1];
+      const doc_page = segments[segments.length - 1];
+      const doc_path = 'dev/' + segments.slice(1, -1).join('/');
+
+      return { page_type: 'dev-page', doc_category: 'dev', doc_product: product, doc_type: product, doc_version: product, doc_page, doc_path };
+    }
+
+    // Fallback for any other docs/ path
+    const doc_path = segments.join('/');
+    return { page_type: 'docs-other', doc_category: segments[0], doc_product: doc_path, doc_type: doc_path, doc_version: doc_path, doc_page: doc_path, doc_path };
   }
 
-  return { page_type: 'other' };
+  // Category hub pages: /desktop-applications, /web-applications, /toolboxes, /dev
+  const hubSegments = path.split('/');
+  if (hubSegments.length === 1) {
+    const name = hubSegments[0];
+    return { page_type: 'hub', doc_category: name, doc_product: name, doc_type: name, doc_version: name, doc_page: name, doc_path: name };
+  }
+
+  // Product hub pages: /desktop-applications/lifesim, /toolboxes/internal-erosion-suite, etc.
+  if (hubSegments.length === 2) {
+    const category = hubSegments[0];
+    const product = hubSegments[1];
+    return { page_type: 'product-hub', doc_category: category, doc_product: product, doc_type: product, doc_version: product, doc_page: product, doc_path: category + '/' + product };
+  }
+
+  // Catch-all for any other page
+  return { page_type: 'other', doc_category: path, doc_product: path, doc_type: path, doc_version: path, doc_page: path, doc_path: path };
 }
 
 // ── Page view tracking (Docusaurus onRouteDidUpdate hook) ───────────
@@ -81,13 +109,13 @@ export function onRouteDidUpdate({ location }) {
 
     window.gtag('event', 'doc_page_view', {
       page_type: dims.page_type,
-      doc_category: dims.doc_category || undefined,
-      doc_product: dims.doc_product || undefined,
-      doc_type: dims.doc_type || undefined,
-      doc_version: dims.doc_version || undefined,
-      doc_page: dims.doc_page || undefined,
-      doc_path: dims.doc_path || undefined,
-      is_latest_version: dims.is_latest_version || undefined,
+      doc_category: dims.doc_category,
+      doc_product: dims.doc_product,
+      doc_type: dims.doc_type,
+      doc_version: dims.doc_version,
+      doc_page: dims.doc_page,
+      doc_path: dims.doc_path,
+      is_latest_version: dims.is_latest_version || 'n/a',
       page_title: document.title,
     });
   });


### PR DESCRIPTION
## Summary
- Expand `parsePath` in `analyticsEvents.js` to return all 7 custom dimensions for every page type (home, changelog, feedback, category hubs, product hubs, dev docs, and catch-all)
- Remove `|| undefined` fallbacks in the gtag event call so every `doc_page_view` event always sends all dimensions
- Eliminates the 83%+ "(not set)" entries in GA4 reports caused by non-doc pages sending undefined dimension values