### PR TITLE
Adjust figure widths in overtopping evaluation process doc

### DIFF
--- a/docs/toolbox-technical-manuals/overtopping-suite/overtopping-erosion-toolbox-notes/v1.0/02-overtopping-evaluation-process.mdx
+++ b/docs/toolbox-technical-manuals/overtopping-suite/overtopping-erosion-toolbox-notes/v1.0/02-overtopping-evaluation-process.mdx
@@ -40,7 +40,7 @@ corresponding to the peak overtopping depths of interest. A generic example is s
   src="figures/toolbox-technical-manuals/overtopping-suite/overtopping-erosion-toolbox-notes/v1.0/figure1.png"
   alt="Overtopping Toolbox Generic Example."
   caption="Overtopping Toolbox Generic Example."
-  width="50%"
+  width="30%"
 />
 
 The toolbox performs a probabilistic analysis using 1,000 iterations. Values of <em>k<sub>d</sub></em> and <em>s<sub>u</sub></em> are randomly sampled based on a
@@ -61,7 +61,7 @@ iteration results are tabulated, and the average SRP value is calculated as show
   src="figures/toolbox-technical-manuals/overtopping-suite/overtopping-erosion-toolbox-notes/v1.0/figure2.png"
   alt="Overtopping Toolbox Generic Example Tabulated results."
   caption="Overtopping Toolbox Generic Example Tabulated results."
-  width="50%"
+  width="30%"
 />
 
 <CitationFootnote />


### PR DESCRIPTION
## Description

- Narrow two figures in the overtopping evaluation process doc from 50% to 30% width for better visual balance on the page

## Affected documents

- [02-overtopping-evaluation-process.mdx](docs/toolbox-technical-manuals/overtopping-suite/overtopping-erosion-toolbox-notes/v1.0/02-overtopping-evaluation-process.mdx)

## Related issue(s)

<!-- Link related issues. Use "Closes #N" to auto-close on merge. -->

## Pre-submission checklist

- [x] I have previewed these changes locally or via the PR preview URL
- [x] My branch name uses one of the expected prefixes: `docs/new/`, `docs/major/`, `docs/minor/`, or `docs/fix/`
- [x] I have updated `00-version-history.mdx` if this change warrants a version entry
- [ ] I have assigned a specific peer reviewer via the Reviewers sidebar (if known)

## Technical edit (Lane 1 only)

- [ ] Technical edit comments addressed — ready for Director review

## Notes for reviewers

<!-- Anything reviewers should know. -->