### PR TITLE
Disable Google Analytics on preview builds

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   build:
@@ -35,8 +36,21 @@ jobs:
             const touchesDocs = files.some(f => f.filename.startsWith('docs/'));
             if (touchesDocs) return; // docs PRs are handled by stage-progression.yml
 
+            // Flip the review-workflow commit status to success so branch
+            // protection allows merge. This is the non-docs counterpart to
+            // stage-progression.yml's status-setting for docs PRs.
+            const headSha = context.payload.pull_request.head.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: headSha,
+              state: 'success',
+              context: 'review-workflow',
+              description: 'No doc changes — admin may merge',
+            });
+
             const marker = '<!-- ci-admin-merge-bot-comment -->';
-            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const sha = headSha.substring(0, 7);
             const body = `${marker}\n\n✅ **CI build passed** for commit \`${sha}\`\n\nThis PR does not touch documentation content under \`docs/\`, so no multi-stage review is required.\n\n@usace-rmc/docs-admin may merge.`;
             const comments = await github.rest.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber });
             const existing = comments.data.find(c => c.user.type === 'Bot' && c.body.includes(marker));

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           DOCUSAURUS_URL: https://usace-rmc.github.io
           DOCUSAURUS_BASE_URL: /RMC-Software-Documentation-Previews/pr-${{ github.event.pull_request.number }}/
+          DOCUSAURUS_IS_PREVIEW: 'true'
         run: npm run build
       - uses: peaceiris/actions-gh-pages@v4
         with:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,14 +89,20 @@ export default {
   ],
 
   plugins: [
-    // Google Analytics plugin
-    [
-      '@docusaurus/plugin-google-gtag',
-      {
-        trackingID: 'G-LB2BWWGDTB',
-        anonymizeIP: true,
-      },
-    ],
+    // Google Analytics plugin — production builds only.
+    // Preview builds set DOCUSAURUS_IS_PREVIEW=true so they don't pollute
+    // the production GA property with pr-preview page views.
+    ...(process.env.DOCUSAURUS_IS_PREVIEW === 'true'
+      ? []
+      : [
+          [
+            '@docusaurus/plugin-google-gtag',
+            {
+              trackingID: 'G-LB2BWWGDTB',
+              anonymizeIP: true,
+            },
+          ],
+        ]),
 
     // TailwindCSS as a custom plugin
     tailwindPlugin,


### PR DESCRIPTION
## Summary
- Skip the \`@docusaurus/plugin-google-gtag\` plugin when \`DOCUSAURUS_IS_PREVIEW=true\` so PR preview deployments stop firing page view events into the production GA property
- pr-preview.yml now sets \`DOCUSAURUS_IS_PREVIEW=true\` in the build env; production builds (deploy.yml, local \`npm run build\`) are unaffected