### PR TITLE
Centralize doc flags and exclude inactive docs from prod build

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,14 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
 import path from 'path';
+import { createRequire } from 'module';
+
+// Load the CommonJS docConfig for the prod-mode exclude list. The docs plugin
+// is happy with glob patterns; we expand each inactive doc_location to a
+// "**/*" glob so every nested MDX under it is excluded from the build.
+const require = createRequire(import.meta.url);
+const { getInactiveDocLocations } = require('./src/docConfig');
+const inactiveDocExcludes = process.env.DOCS_MODE === 'prod' ? getInactiveDocLocations().map((loc) => `${loc}/**`) : [];
 
 // Normalize the drive letter to uppercase on Windows to prevent webpack
 // "modules with names that only differ in casing" warnings.
@@ -69,6 +77,7 @@ export default {
           remarkPlugins: [remarkMath, remarkGfm],
           rehypePlugins: [rehypeKatex],
           breadcrumbs: true,
+          exclude: inactiveDocExcludes,
         },
         theme: {
           customCss: normalizeDriveLetter(require.resolve('./src/css/custom.css')),

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@tailwindcss/postcss": "^4.1.11",
         "autoprefixer": "^10.4.21",
         "baseline-browser-mapping": "^2.9.19",
+        "cross-env": "^7.0.3",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.6.14"
@@ -8139,6 +8140,25 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "report-map": "node scripts/generateReportIdMap.js",
     "generate-toc": "node scripts/generateEventTreeTOC.js",
     "image-dims": "node scripts/generateImageDimensions.js",
-    "start": "npm run image-dims && npm run report-map && npm run sidebars && npm run counters && npm run versions && npm run generate-toc && docusaurus start",
-    "build": "npm run image-dims && npm run report-map && npm run sidebars && npm run counters && npm run versions && npm run generate-toc && docusaurus build",
+    "start": "cross-env DOCS_MODE=dev npm run image-dims && cross-env DOCS_MODE=dev npm run report-map && cross-env DOCS_MODE=dev npm run sidebars && cross-env DOCS_MODE=dev npm run counters && cross-env DOCS_MODE=dev npm run versions && cross-env DOCS_MODE=dev npm run generate-toc && cross-env DOCS_MODE=dev docusaurus start",
+    "build": "cross-env DOCS_MODE=prod npm run image-dims && cross-env DOCS_MODE=prod npm run report-map && cross-env DOCS_MODE=prod npm run sidebars && cross-env DOCS_MODE=prod npm run counters && cross-env DOCS_MODE=prod npm run versions && cross-env DOCS_MODE=prod npm run generate-toc && cross-env DOCS_MODE=prod docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -51,6 +51,7 @@
     "@tailwindcss/postcss": "^4.1.11",
     "autoprefixer": "^10.4.21",
     "baseline-browser-mapping": "^2.9.19",
+    "cross-env": "^7.0.3",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14"

--- a/scripts/counters.js
+++ b/scripts/counters.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const reportIdMap = require('../src/reportIdMap'); // Importing the map correctly
+const { shouldExcludeFromBuild } = require('../src/docConfig');
 
 // Base paths
 const docsBasePath = path.join(__dirname, '../docs');
@@ -172,6 +173,12 @@ const allDocPaths = findAllDocumentPaths(docsBasePath);
 
 for (const docPath of allDocPaths) {
   const normalizedDocPath = normalizePath(docPath); // Normalize path here
+
+  // In prod, skip counters generation for docs flagged inactive in
+  // src/docConfig.js — they won't be in the build, so the counters would be
+  // dead weight.
+  if (shouldExcludeFromBuild(normalizedDocPath)) continue;
+
   const reportId = reportIdMap[normalizedDocPath];
 
   if (reportId) {

--- a/scripts/generateReportIdMap.js
+++ b/scripts/generateReportIdMap.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const { shouldExcludeFromBuild } = require("../src/docConfig");
 
 const DOCS_PATH = path.join(__dirname, "../docs");
 const OUTPUT_FILE = path.join(__dirname, "../src/reportIdMap.js");
@@ -26,11 +27,16 @@ function walkDocs(currentPath, relPath = []) {
         const subHub = relPath[relPath.length - 2]; // One level above documentName
 
         const docPath = newRelPath.join("/");
+        const docBasePath = relPath.join("/"); // Path without the version suffix
 
         if (!subHub || !documentName) {
           console.warn(`⚠️ Skipping: Incomplete path at ${docPath}`);
           return;
         }
+
+        // In prod, skip docs flagged inactive in src/docConfig.js so report
+        // IDs aren't generated for content that won't exist in the build.
+        if (shouldExcludeFromBuild(docBasePath)) return;
 
         const reportId = `${subHub}-${documentName}-${version}`;
         reportIdMap[docPath] = reportId;

--- a/scripts/generateSidebars.js
+++ b/scripts/generateSidebars.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { shouldExcludeFromBuild } = require('../src/docConfig');
 
 const DOCS_DIR = path.join(__dirname, '..', 'docs');
 const SIDEBAR_PATH = path.join(__dirname, '..', 'sidebars.js');
@@ -593,6 +594,10 @@ function generateSidebars() {
 
     const docPath = versionMatch[1];
     const version = versionMatch[2];
+
+    // In prod, skip docs flagged inactive in src/docConfig.js so the sidebar
+    // doesn't reference doc IDs that the docs plugin will exclude.
+    if (shouldExcludeFromBuild(docPath)) return;
     const docParts = docPath.split('/');
     const docGroup = docParts[1]; // e.g., "rmc-totalrisk"
     const folderName = docParts[docParts.length - 1]; // e.g., "applications-guide"

--- a/scripts/versions.js
+++ b/scripts/versions.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { shouldExcludeFromBuild } = require('../src/docConfig');
 
 // Define the base path for your docs folder
 const docsFolderPath = path.join(__dirname, '..', 'docs');
@@ -106,16 +107,20 @@ function generateVersions() {
     }
   });
 
-  // Convert keys to forward slashes
+  // Convert keys to forward slashes; in prod mode, drop inactive docs entirely
+  // so they don't appear in latestVersions, versionList, or the Algolia
+  // crawler config.
   const updatedLatestVersions = {};
   const updatedAllVersions = {};
 
   for (const key in latestVersions) {
     const newKey = key.replace(/\\/g, '/');
+    if (shouldExcludeFromBuild(newKey)) continue;
     updatedLatestVersions[newKey] = latestVersions[key];
   }
   for (const key in allVersions) {
     const newKey = key.replace(/\\/g, '/');
+    if (shouldExcludeFromBuild(newKey)) continue;
     updatedAllVersions[newKey] = allVersions[key];
   }
 

--- a/src/components/ContentBubble.js
+++ b/src/components/ContentBubble.js
@@ -37,6 +37,18 @@ const ContentBubble = ({
     pointer-events-none cursor-not-allowed
   `;
 
+  // In dev, allow inactive ("Coming Soon") tiles to be clickable so contributors
+  // can preview docs they're working on without flipping the active flag. In
+  // prod, the tile remains a non-clickable visual placeholder. Webpack injects
+  // process.env.NODE_ENV at build time: 'development' for `npm start`,
+  // 'production' for `npm run build`.
+  const isDevPreviewable = !active && process.env.NODE_ENV === 'development' && (doc_location || downloadUrl);
+  const inactiveDevClasses = `
+    coming-soon-gradient-card
+    hover:scale-[1.02]
+    cursor-pointer
+  `;
+
   // Build <ThemedImage /> sources, with fallback to legacy `icon`
   const sources = iconLight || icon ? { light: iconLight ?? icon, dark: iconDark ?? iconLight ?? icon } : null;
 
@@ -74,11 +86,23 @@ const ContentBubble = ({
     );
   }
 
-  return active ? (
-    <a href={doc_location} className={`${baseClasses} ${activeClasses}`}>
-      <Inner isDraft={draft} />
-    </a>
-  ) : (
+  if (active) {
+    return (
+      <a href={doc_location} className={`${baseClasses} ${activeClasses}`}>
+        <Inner isDraft={draft} />
+      </a>
+    );
+  }
+
+  if (isDevPreviewable) {
+    return (
+      <a href={downloadUrl ?? doc_location} className={`${baseClasses} ${inactiveDevClasses}`} {...(downloadUrl ? { download: true } : {})}>
+        <Inner comingSoon isDraft={draft} />
+      </a>
+    );
+  }
+
+  return (
     <div className={`${baseClasses} ${inactiveClasses}`}>
       <Inner comingSoon />
     </div>

--- a/src/docConfig.js
+++ b/src/docConfig.js
@@ -1,0 +1,350 @@
+/**
+ * Central source of truth for document status flags.
+ *
+ * This file is consumed by both the React app (landing pages) and the build
+ * scripts (sidebars, versions, counters, report-map, docusaurus.config.js).
+ * It is therefore written in CommonJS so Node scripts can `require()` it
+ * directly without a transpile step.
+ *
+ * Each entry describes one document tile shown on a landing page. The
+ * `category` and `software` fields are used by landing pages to filter the
+ * list; the `active` and `draft` flags drive build inclusion, search
+ * indexing, landing-page tile state, and the draft watermark.
+ *
+ * Active flag (controls site presence):
+ *   active: true  → doc is built, served, sidebar-registered, and indexed by Algolia.
+ *   active: false → doc is NOT included in the prod build (no static HTML, no
+ *                   sidebar, no Algolia entry). Landing-page renders a
+ *                   "Coming Soon" tile. In dev (DOCS_MODE=dev) the doc is
+ *                   built so contributors can work on it freely.
+ *
+ * Draft flag (controls watermark only):
+ *   draft: true   → DRAFT watermark renders on the latest version of the doc.
+ *   draft: false  → no watermark.
+ *
+ * The two flags are orthogonal. A doc may be active+draft (published draft
+ * with watermark, fully searchable) or inactive+draft (unpublished, no
+ * watermark visible because the doc isn't on the prod site).
+ *
+ * Download-only entries (downloadUrl, no doc_location) are tiles that link
+ * directly to a PDF — they have no associated MDX folder and are unaffected
+ * by the active/draft build-inclusion logic.
+ */
+
+const docs = [
+  // --- Desktop Applications: LifeSim ---
+  {
+    category: 'desktop-applications',
+    software: 'lifesim',
+    doc_location: 'desktop-applications/lifesim/users-guide',
+    doc_name: 'LifeSim Users Guide',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'desktop-applications',
+    software: 'lifesim',
+    doc_location: 'desktop-applications/lifesim/validation-studies',
+    doc_name: 'LifeSim Validation Studies',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'desktop-applications',
+    software: 'lifesim',
+    doc_name: 'LifeSim Technical Reference Manual',
+    active: true,
+    draft: false,
+    downloadUrl: '/source-documents/desktop-applications/lifesim/technical-reference-manual/LifeSim-Technical-Reference-Manual.pdf',
+  },
+  {
+    category: 'desktop-applications',
+    software: 'lifesim',
+    doc_location: 'desktop-applications/lifesim/applications-guide',
+    doc_name: 'LifeSim Applications Guide',
+    active: false,
+    draft: false,
+  },
+
+  // --- Desktop Applications: RMC TotalRisk ---
+  {
+    category: 'desktop-applications',
+    software: 'rmc-totalrisk',
+    doc_location: 'desktop-applications/rmc-totalrisk/users-guide',
+    doc_name: 'RMC TotalRisk Users Guide',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'desktop-applications',
+    software: 'rmc-totalrisk',
+    doc_name: 'RMC TotalRisk Verification Report',
+    active: true,
+    draft: true,
+    downloadUrl: '/source-documents/desktop-applications/rmc-totalrisk/verification-report/RMC-TotalRisk-Verification-Report.pdf',
+  },
+  {
+    category: 'desktop-applications',
+    software: 'rmc-totalrisk',
+    doc_name: 'RMC TotalRisk Technical Reference Manual',
+    active: true,
+    draft: true,
+    downloadUrl: '/source-documents/desktop-applications/rmc-totalrisk/technical-reference-manual/RMC-TotalRisk-Technical-Reference-Manual.pdf',
+  },
+  {
+    category: 'desktop-applications',
+    software: 'rmc-totalrisk',
+    doc_location: 'desktop-applications/rmc-totalrisk/applications-guide',
+    doc_name: 'RMC TotalRisk Applications Guide',
+    active: false,
+    draft: true,
+  },
+
+  // --- Desktop Applications: RMC RFA ---
+  {
+    category: 'desktop-applications',
+    software: 'rmc-rfa',
+    doc_location: 'desktop-applications/rmc-rfa/users-guide',
+    doc_name: 'RMC RFA Users Guide',
+    active: true,
+    draft: false,
+  },
+
+  // --- Desktop Applications: RMC BestFit ---
+  {
+    category: 'desktop-applications',
+    software: 'rmc-bestfit',
+    doc_location: 'desktop-applications/rmc-bestfit/users-guide',
+    doc_name: 'RMC BestFit Users Guide',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'desktop-applications',
+    software: 'rmc-bestfit',
+    doc_name: 'RMC-BestFit Verification Report',
+    active: true,
+    draft: false,
+    downloadUrl: '/source-documents/desktop-applications/rmc-bestfit/verification-report/RMC-BestFit-Verification-Report.pdf',
+  },
+
+  // --- Toolboxes: Internal Erosion Suite ---
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/backward-erosion-piping-initiation',
+    doc_name: 'Backward Erosion Piping (Initiation) Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/backward-erosion-piping-progression',
+    doc_name: 'Backward Erosion Piping (Progression) Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/breach',
+    doc_name: 'Breach Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/concentrated-leak-erosion-cracking',
+    doc_name: 'Concentrated Leak Erosion (Cracking) Toolbox Technical Manual',
+    active: false,
+    draft: true,
+  },
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/concentrated-leak-erosion-initiation',
+    doc_name: 'Concentrated Leak Erosion (Initiation) Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/filter-evaluation-continuation',
+    doc_name: 'Filter Evaluation (Continuation) Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/internal-instability',
+    doc_name: 'Internal Instability Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/pipe-service-life',
+    doc_name: 'Pipe Service Life (Flaw) Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'internal-erosion-suite',
+    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/soil-contact-erosion-initiation',
+    doc_name: 'Soil Contact Erosion (Initiation) Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+
+  // --- Toolboxes: Overtopping Suite ---
+  {
+    category: 'toolboxes',
+    software: 'overtopping-suite',
+    doc_location: 'toolbox-technical-manuals/overtopping-suite/riprap-stability',
+    doc_name: 'Riprap Stability Toolbox Technical Manual',
+    active: false,
+    draft: true,
+  },
+  {
+    category: 'toolboxes',
+    software: 'overtopping-suite',
+    doc_location: 'toolbox-technical-manuals/overtopping-suite/wave-overtopping',
+    doc_name: 'Wave Overtopping Toolbox Technical Manual',
+    active: false,
+    draft: true,
+  },
+  {
+    category: 'toolboxes',
+    software: 'overtopping-suite',
+    doc_location: 'toolbox-technical-manuals/overtopping-suite/scour-behind-floodwalls',
+    doc_name: 'Scour Behind Floodwalls Toolbox Technical Manual',
+    active: false,
+    draft: true,
+  },
+  {
+    category: 'toolboxes',
+    software: 'overtopping-suite',
+    doc_location: 'toolbox-technical-manuals/overtopping-suite/overtopping-erosion-toolbox-notes',
+    doc_name: 'Overtopping Erosion Toolbox User Notes',
+    active: true,
+    draft: false,
+  },
+
+  // --- Toolboxes: Risk Calculations Suite ---
+  {
+    category: 'toolboxes',
+    software: 'risk-calculations-suite',
+    doc_location: 'toolbox-technical-manuals/risk-calculations-suite/typical-event-tree-database',
+    doc_name: 'Typical Event Tree Database',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'risk-calculations-suite',
+    doc_location: 'toolbox-technical-manuals/risk-calculations-suite/sqra-calcs',
+    doc_name: 'SQRAcalcs Toolbox Technical Manual',
+    active: false,
+    draft: true,
+  },
+  {
+    category: 'toolboxes',
+    software: 'risk-calculations-suite',
+    doc_location: 'toolbox-technical-manuals/risk-calculations-suite/event-combination',
+    doc_name: 'Event Combination Toolbox Technical Manual',
+    active: false,
+    draft: true,
+  },
+  {
+    category: 'toolboxes',
+    software: 'risk-calculations-suite',
+    doc_location: 'toolbox-technical-manuals/risk-calculations-suite/risk-management-plans',
+    doc_name: 'Risk Management Plans Toolbox Technical Manual',
+    active: false,
+    draft: true,
+  },
+
+  // --- Toolboxes: Seismic Hazard Suite ---
+  {
+    category: 'toolboxes',
+    software: 'seismic-hazard-suite',
+    doc_location: 'toolbox-technical-manuals/seismic-hazard-suite/site-classification',
+    doc_name: 'Site Classification Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+  {
+    category: 'toolboxes',
+    software: 'seismic-hazard-suite',
+    doc_location: 'toolbox-technical-manuals/seismic-hazard-suite/seismic-hazard-curves',
+    doc_name: 'Seismic Hazard Curves Toolbox Technical Manual',
+    active: true,
+    draft: false,
+  },
+
+  // --- Web Applications: DST ---
+  {
+    category: 'web-applications',
+    software: 'dst',
+    doc_location: 'web-applications/dst/users-guide',
+    doc_name: 'Dam Screening Tool Users Guide',
+    active: false,
+    draft: true,
+  },
+
+  // --- Web Applications: LST ---
+  {
+    category: 'web-applications',
+    software: 'lst',
+    doc_location: 'web-applications/lst/users-guide',
+    doc_name: 'Levee Screening Tool Users Guide',
+    active: false,
+    draft: true,
+  },
+
+  // --- Web Applications: RRFT ---
+  {
+    category: 'web-applications',
+    software: 'rrft',
+    doc_location: 'web-applications/rrft/users-guide',
+    doc_name: 'RRFT Users Guide',
+    active: false,
+    draft: true,
+  },
+];
+
+function filterByCategoryAndSoftware(category, software) {
+  return docs.filter((doc) => doc.category === category && doc.software === software);
+}
+
+function getInactiveDocLocations() {
+  return docs.filter((doc) => doc.active === false && doc.doc_location).map((doc) => doc.doc_location);
+}
+
+function getDraftDocLocations() {
+  return docs.filter((doc) => doc.draft === true && doc.doc_location).map((doc) => doc.doc_location);
+}
+
+// Used by build scripts to decide whether a docs-relative path (e.g.
+// "web-applications/lst/users-guide" or any nested file under it) should be
+// excluded from the prod build. In dev (DOCS_MODE !== 'prod'), nothing is
+// excluded — contributors can work on inactive docs freely.
+function shouldExcludeFromBuild(docsRelativePath) {
+  if (process.env.DOCS_MODE !== 'prod') return false;
+  const normalized = String(docsRelativePath).replace(/\\/g, '/').replace(/^\/+/, '');
+  return getInactiveDocLocations().some((loc) => normalized === loc || normalized.startsWith(loc + '/'));
+}
+
+module.exports = {
+  docs,
+  filterByCategoryAndSoftware,
+  getInactiveDocLocations,
+  getDraftDocLocations,
+  shouldExcludeFromBuild,
+};

--- a/src/draftDocs.js
+++ b/src/draftDocs.js
@@ -1,32 +1,3 @@
-import { lifeSimDocs } from './pages/desktop-applications/lifesim';
-import { bestFitDocs } from './pages/desktop-applications/rmc-bestfit';
-import { RFADocs } from './pages/desktop-applications/rmc-rfa';
-import { totalRiskDocs } from './pages/desktop-applications/rmc-totalrisk';
-import { internalErosionSuiteDocs } from './pages/toolboxes/internal-erosion-suite';
-import { overtoppingSuiteDocs } from './pages/toolboxes/overtopping-suite';
-import { riskCalculationsSuiteDocs } from './pages/toolboxes/risk-calculations-suite';
-import { seismicHazardSuiteDocs } from './pages/toolboxes/seismic-hazard-suite';
-import { dstDocs } from './pages/web-applications/dst';
-import { lstDocs } from './pages/web-applications/lst';
-import { rrftDocs } from './pages/web-applications/rrft';
-// import { otherCategoryDocs } from "./pages/toolboxes/other-category"; // Add more as needed
+import { getDraftDocLocations } from './docConfig';
 
-const allDocs = [
-  ...internalErosionSuiteDocs,
-  ...riskCalculationsSuiteDocs,
-  ...seismicHazardSuiteDocs,
-  ...overtoppingSuiteDocs,
-  ...lifeSimDocs,
-  ...bestFitDocs,
-  ...RFADocs,
-  ...totalRiskDocs,
-  ...dstDocs,
-  ...lstDocs,
-  ...rrftDocs,
-  // ...otherCategoryDocs,
-];
-
-export const draftDocs = allDocs
-  .filter((doc) => doc.draft)
-  .map((doc) => doc.doc_location)
-  .filter(Boolean);
+export const draftDocs = getDraftDocLocations();

--- a/src/pages/desktop-applications/lifesim.js
+++ b/src/pages/desktop-applications/lifesim.js
@@ -3,43 +3,16 @@ import Layout from '@theme/Layout';
 import ThemedImage from '@theme/ThemedImage';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const lifeSimData = [
-  {
-    icon: 'img/LifeSim.png',
-    preserveIconColor: true,
-    doc_location: 'desktop-applications/lifesim/users-guide',
-    doc_name: 'LifeSim Users Guide',
-    active: true,
-    draft: false,
-  },
-  {
-    icon: 'img/LifeSim.png',
-    preserveIconColor: true,
-    doc_location: 'desktop-applications/lifesim/validation-studies',
-    doc_name: 'LifeSim Validation Studies',
-    active: true,
-    draft: false,
-  },
-  {
-    icon: 'img/LifeSim.png',
-    preserveIconColor: true,
-    doc_name: 'LifeSim Technical Reference Manual',
-    active: true,
-    draft: false,
-    downloadUrl: '/source-documents/desktop-applications/lifesim/technical-reference-manual/LifeSim-Technical-Reference-Manual.pdf',
-  },
-  {
-    icon: 'img/LifeSim.png',
-    preserveIconColor: true,
-    doc_location: 'desktop-applications/lifesim/applications-guide',
-    doc_name: 'LifeSim Applications Guide',
-    active: false,
-    draft: false,
-  },
-];
+const ICON = 'img/LifeSim.png';
+
+const lifeSimData = filterByCategoryAndSoftware('desktop-applications', 'lifesim').map((doc) => ({
+  ...doc,
+  icon: ICON,
+  preserveIconColor: true,
+}));
 
 export const lifeSimDocs = lifeSimData;
 

--- a/src/pages/desktop-applications/rmc-bestfit.js
+++ b/src/pages/desktop-applications/rmc-bestfit.js
@@ -3,27 +3,16 @@ import Layout from '@theme/Layout';
 import ThemedImage from '@theme/ThemedImage';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const bestFitData = [
-  {
-    icon: 'img/BestFit.png',
-    preserveIconColor: true,
-    doc_location: 'desktop-applications/rmc-bestfit/users-guide',
-    doc_name: 'RMC BestFit Users Guide',
-    active: true,
-    draft: false,
-  },
-  {
-    icon: 'img/BestFit.png',
-    preserveIconColor: true,
-    doc_name: 'RMC-BestFit Verification Report',
-    active: true,
-    draft: false,
-    downloadUrl: '/source-documents/desktop-applications/rmc-bestfit/verification-report/RMC-BestFit-Verification-Report.pdf',
-  },
-];
+const ICON = 'img/BestFit.png';
+
+const bestFitData = filterByCategoryAndSoftware('desktop-applications', 'rmc-bestfit').map((doc) => ({
+  ...doc,
+  icon: ICON,
+  preserveIconColor: true,
+}));
 
 export const bestFitDocs = bestFitData;
 
@@ -31,7 +20,6 @@ export default function BestFit() {
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    // Fetch the latestVersions JSON file
     fetch('/RMC-Software-Documentation/versions/latestVersions.json')
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))

--- a/src/pages/desktop-applications/rmc-rfa.js
+++ b/src/pages/desktop-applications/rmc-rfa.js
@@ -3,19 +3,16 @@ import Layout from '@theme/Layout';
 import ThemedImage from '@theme/ThemedImage';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const RFAData = [
-  {
-    icon: 'img/RFA.png',
-    preserveIconColor: true,
-    doc_location: 'desktop-applications/rmc-rfa/users-guide',
-    doc_name: 'RMC RFA Users Guide',
-    active: true,
-    draft: false,
-  },
-];
+const ICON = 'img/RFA.png';
+
+const RFAData = filterByCategoryAndSoftware('desktop-applications', 'rmc-rfa').map((doc) => ({
+  ...doc,
+  icon: ICON,
+  preserveIconColor: true,
+}));
 
 export const RFADocs = RFAData;
 
@@ -23,7 +20,6 @@ export default function RFA() {
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    // Fetch the latestVersions JSON file
     fetch('/RMC-Software-Documentation/versions/latestVersions.json')
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))

--- a/src/pages/desktop-applications/rmc-totalrisk.js
+++ b/src/pages/desktop-applications/rmc-totalrisk.js
@@ -3,43 +3,16 @@ import Layout from '@theme/Layout';
 import ThemedImage from '@theme/ThemedImage';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const totalRiskData = [
-  {
-    icon: 'img/TotalRisk.png',
-    preserveIconColor: true,
-    doc_location: 'desktop-applications/rmc-totalrisk/users-guide',
-    doc_name: 'RMC TotalRisk Users Guide',
-    active: true,
-    draft: false,
-  },
-  {
-    icon: 'img/TotalRisk.png',
-    preserveIconColor: true,
-    doc_name: 'RMC TotalRisk Verification Report',
-    active: true,
-    draft: true,
-    downloadUrl: '/source-documents/desktop-applications/rmc-totalrisk/verification-report/RMC-TotalRisk-Verification-Report.pdf',
-  },
-  {
-    icon: 'img/TotalRisk.png',
-    preserveIconColor: true,
-    doc_name: 'RMC TotalRisk Technical Reference Manual',
-    active: true,
-    draft: true,
-    downloadUrl: '/source-documents/desktop-applications/rmc-totalrisk/technical-reference-manual/RMC-TotalRisk-Technical-Reference-Manual.pdf',
-  },
-  {
-    icon: 'img/TotalRisk.png',
-    preserveIconColor: true,
-    doc_location: 'desktop-applications/rmc-totalrisk/applications-guide',
-    doc_name: 'RMC TotalRisk Applications Guide',
-    active: false,
-    draft: true,
-  },
-];
+const ICON = 'img/TotalRisk.png';
+
+const totalRiskData = filterByCategoryAndSoftware('desktop-applications', 'rmc-totalrisk').map((doc) => ({
+  ...doc,
+  icon: ICON,
+  preserveIconColor: true,
+}));
 
 export const totalRiskDocs = totalRiskData;
 
@@ -47,7 +20,6 @@ export default function TotalRisk() {
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    // Fetch the latestVersions JSON file
     fetch('/RMC-Software-Documentation/versions/latestVersions.json')
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))

--- a/src/pages/toolboxes/internal-erosion-suite.js
+++ b/src/pages/toolboxes/internal-erosion-suite.js
@@ -3,74 +3,13 @@ import Layout from '@theme/Layout';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
 import ToolboxIcon from '../../components/icons/ToolboxIcon';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const internalErosionSuite = [
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/internal-erosion-suite/backward-erosion-piping-initiation`,
-    doc_name: 'Backward Erosion Piping (Initiation) Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: 'toolbox-technical-manuals/internal-erosion-suite/backward-erosion-piping-progression',
-    doc_name: 'Backward Erosion Piping (Progression) Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/internal-erosion-suite/breach`,
-    doc_name: 'Breach Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/internal-erosion-suite/concentrated-leak-erosion-cracking`,
-    doc_name: 'Concentrated Leak Erosion (Cracking) Toolbox Technical Manual',
-    active: false,
-    draft: true,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/internal-erosion-suite/concentrated-leak-erosion-initiation`,
-    doc_name: 'Concentrated Leak Erosion (Initiation) Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/internal-erosion-suite/filter-evaluation-continuation`,
-    doc_name: 'Filter Evaluation (Continuation) Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/internal-erosion-suite/internal-instability`,
-    doc_name: 'Internal Instability Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/internal-erosion-suite/pipe-service-life`,
-    doc_name: 'Pipe Service Life (Flaw) Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/internal-erosion-suite/soil-contact-erosion-initiation`,
-    doc_name: 'Soil Contact Erosion (Initiation) Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-];
+const internalErosionSuite = filterByCategoryAndSoftware('toolboxes', 'internal-erosion-suite').map((doc) => ({
+  ...doc,
+  IconComponent: ToolboxIcon,
+}));
 
 export const internalErosionSuiteDocs = internalErosionSuite;
 

--- a/src/pages/toolboxes/overtopping-suite.js
+++ b/src/pages/toolboxes/overtopping-suite.js
@@ -3,39 +3,13 @@ import Layout from '@theme/Layout';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
 import ToolboxIcon from '../../components/icons/ToolboxIcon';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const overtoppingSuite = [
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/overtopping-suite/riprap-stability`,
-    doc_name: 'Riprap Stability Toolbox Technical Manual',
-    active: false,
-    draft: true,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/overtopping-suite/wave-overtopping`,
-    doc_name: 'Wave Overtopping Toolbox Technical Manual',
-    active: false,
-    draft: true,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/overtopping-suite/scour-behind-floodwalls`,
-    doc_name: 'Scour Behind Floodwalls Toolbox Technical Manual',
-    active: false,
-    draft: true,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/overtopping-suite/overtopping-erosion-toolbox-notes`,
-    doc_name: 'Overtopping Erosion Toolbox User Notes',
-    active: true,
-    draft: false,
-  },
-];
+const overtoppingSuite = filterByCategoryAndSoftware('toolboxes', 'overtopping-suite').map((doc) => ({
+  ...doc,
+  IconComponent: ToolboxIcon,
+}));
 
 export const overtoppingSuiteDocs = overtoppingSuite;
 

--- a/src/pages/toolboxes/risk-calculations-suite.js
+++ b/src/pages/toolboxes/risk-calculations-suite.js
@@ -3,39 +3,13 @@ import Layout from '@theme/Layout';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
 import ToolboxIcon from '../../components/icons/ToolboxIcon';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const riskCalculationsSuite = [
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/risk-calculations-suite/typical-event-tree-database`,
-    doc_name: 'Typical Event Tree Database',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/risk-calculations-suite/sqra-calcs`,
-    doc_name: 'SQRAcalcs Toolbox Technical Manual',
-    active: false,
-    draft: true,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/risk-calculations-suite/event-combination`,
-    doc_name: 'Event Combination Toolbox Technical Manual',
-    active: false,
-    draft: true,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/risk-calculations-suite/risk-management-plans`,
-    doc_name: 'Risk Management Plans Toolbox Technical Manual',
-    active: false,
-    draft: true,
-  },
-];
+const riskCalculationsSuite = filterByCategoryAndSoftware('toolboxes', 'risk-calculations-suite').map((doc) => ({
+  ...doc,
+  IconComponent: ToolboxIcon,
+}));
 
 export const riskCalculationsSuiteDocs = riskCalculationsSuite;
 

--- a/src/pages/toolboxes/seismic-hazard-suite.js
+++ b/src/pages/toolboxes/seismic-hazard-suite.js
@@ -3,25 +3,13 @@ import Layout from '@theme/Layout';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
 import ToolboxIcon from '../../components/icons/ToolboxIcon';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const seismicHazardSuite = [
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/seismic-hazard-suite/site-classification`,
-    doc_name: 'Site Classification Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-  {
-    IconComponent: ToolboxIcon,
-    doc_location: `toolbox-technical-manuals/seismic-hazard-suite/seismic-hazard-curves`,
-    doc_name: 'Seismic Hazard Curves Toolbox Technical Manual',
-    active: true,
-    draft: false,
-  },
-];
+const seismicHazardSuite = filterByCategoryAndSoftware('toolboxes', 'seismic-hazard-suite').map((doc) => ({
+  ...doc,
+  IconComponent: ToolboxIcon,
+}));
 
 export const seismicHazardSuiteDocs = seismicHazardSuite;
 

--- a/src/pages/web-applications/dst.js
+++ b/src/pages/web-applications/dst.js
@@ -3,18 +3,13 @@ import Layout from '@theme/Layout';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
 import DSTIcon from '../../components/icons/DSTIcon';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const dstData = [
-  {
-    IconComponent: DSTIcon,
-    doc_location: 'web-applications/dst/users-guide',
-    doc_name: 'Dam Screening Tool Users Guide',
-    active: false,
-    draft: true,
-  },
-];
+const dstData = filterByCategoryAndSoftware('web-applications', 'dst').map((doc) => ({
+  ...doc,
+  IconComponent: DSTIcon,
+}));
 
 export const dstDocs = dstData;
 
@@ -22,7 +17,6 @@ export default function DST() {
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    // Fetch the latestVersions JSON file
     fetch('/RMC-Software-Documentation/versions/latestVersions.json')
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))

--- a/src/pages/web-applications/lst.js
+++ b/src/pages/web-applications/lst.js
@@ -3,18 +3,13 @@ import Layout from '@theme/Layout';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
 import LSTIcon from '../../components/icons/LSTIcon';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const lstData = [
-  {
-    IconComponent: LSTIcon,
-    doc_location: 'web-applications/lst/users-guide',
-    doc_name: 'Levee Screening Tool Users Guide',
-    active: false,
-    draft: true,
-  },
-];
+const lstData = filterByCategoryAndSoftware('web-applications', 'lst').map((doc) => ({
+  ...doc,
+  IconComponent: LSTIcon,
+}));
 
 export const lstDocs = lstData;
 
@@ -22,7 +17,6 @@ export default function LST() {
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    // Fetch the latestVersions JSON file
     fetch('/RMC-Software-Documentation/versions/latestVersions.json')
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))

--- a/src/pages/web-applications/rrft.js
+++ b/src/pages/web-applications/rrft.js
@@ -3,18 +3,13 @@ import Layout from '@theme/Layout';
 import { useEffect, useState } from 'react';
 import ContentBox from '../../components/ContentBox';
 import RRFTIcon from '../../components/icons/RRFTIcon';
+import { filterByCategoryAndSoftware } from '../../docConfig';
 import '../../css/custom.css';
 
-// Create the list of documents dynamically
-const rrftData = [
-  {
-    IconComponent: RRFTIcon,
-    doc_location: 'web-applications/rrft/users-guide',
-    doc_name: 'RRFT Users Guide',
-    active: false,
-    draft: true,
-  },
-];
+const rrftData = filterByCategoryAndSoftware('web-applications', 'rrft').map((doc) => ({
+  ...doc,
+  IconComponent: RRFTIcon,
+}));
 
 export const rrftDocs = rrftData;
 
@@ -22,7 +17,6 @@ export default function RRFT() {
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    // Fetch the latestVersions JSON file
     fetch('/RMC-Software-Documentation/versions/latestVersions.json')
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))


### PR DESCRIPTION
## Summary
- Centralize `active` and `draft` flags for all 30 doc tiles into a single `src/docConfig.js`, replacing scattered definitions across 11 landing-page files
- Exclude `active: false` docs from the prod build entirely — no static HTML, no sidebar entry, no `latestVersions.json` entry, no `algoliaCrawlerVersions.json` entry — so unpublished documents like the LST Users Guide stop appearing in Algolia search
- Keep inactive docs accessible in dev (`DOCS_MODE=dev`) and make Coming Soon tiles clickable in dev so contributors can preview drafts without flipping the active flag