### PR TITLE
Fix hardcoded base URLs so PR previews load assets correctly

### DIFF
--- a/src/clientModules/analyticsEvents.js
+++ b/src/clientModules/analyticsEvents.js
@@ -10,7 +10,9 @@
  *   search_query  — when a user searches via Algolia DocSearch
  */
 
-const BASE_PATH = '/RMC-Software-Documentation/';
+import siteConfig from '@generated/docusaurus.config';
+
+const BASE_PATH = siteConfig.baseUrl;
 
 // ── Latest versions cache ───────────────────────────────────────────
 

--- a/src/components/Bibliography.js
+++ b/src/components/Bibliography.js
@@ -1,17 +1,21 @@
 import React, { useState, useEffect } from "react";
 import { useLocation } from "@docusaurus/router";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import { useReportId } from "../contexts/ReportIdContext";
 
 const Bibliography = () => {
   const [citations, setCitations] = useState([]);
   const location = useLocation();
   const reportId = useReportId ? useReportId() : null;
+  const docsBase = useBaseUrl("docs/");
+  const bibsBase = useBaseUrl("bibliographies/");
+  const countersBase = useBaseUrl("counters/");
 
   // Extract the current path from the URL
   const pathname = location.pathname;
-  const reportPath = pathname.replace(/^\/RMC-Software-Documentation\/docs\//, "/RMC-Software-Documentation/bibliographies/").replace(/\/[^/]*$/, "");
+  const reportPath = pathname.replace(docsBase, bibsBase).replace(/\/[^/]*$/, "");
   const bibFilePath = `${reportPath}/bib.json`;
-  const countersFilePath = reportId ? `/RMC-Software-Documentation/counters/${reportId}.json` : null;
+  const countersFilePath = reportId ? `${countersBase}${reportId}.json` : null;
 
   useEffect(() => {
     let isMounted = true;

--- a/src/components/Citation.js
+++ b/src/components/Citation.js
@@ -1,4 +1,5 @@
 import { useLocation } from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useEffect, useState, useSyncExternalStore } from 'react';
 import { useReportId } from '../contexts/ReportIdContext';
 import '../css/custom.css';
@@ -70,14 +71,13 @@ const Citation = ({ citationKey }) => {
   const location = useLocation();
   const pathname = location.pathname; // treat as docId
   const reportId = useReportId ? useReportId() : null;
+  const docsBase = useBaseUrl('docs/');
+  const bibsBase = useBaseUrl('bibliographies/');
+  const countersBase = useBaseUrl('counters/');
 
-  const reportPath = pathname
-    .replace(/^\/RMC-Software-Documentation\/docs\//, '/RMC-Software-Documentation/bibliographies/')
-    .replace(/\/[^/]*$/, '');
+  const reportPath = pathname.replace(docsBase, bibsBase).replace(/\/[^/]*$/, '');
   const bibFilePath = `${reportPath}/bib.json`;
-  const countersFilePath = reportId
-    ? `/RMC-Software-Documentation/counters/${reportId}.json`
-    : null;
+  const countersFilePath = reportId ? `${countersBase}${reportId}.json` : null;
 
   // Number comes from counters (original logic)
   useEffect(() => {

--- a/src/components/CitationFootnote.js
+++ b/src/components/CitationFootnote.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useUsedCitations } from "./Citation";
 import { useLocation } from "@docusaurus/router";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import { useReportId } from "../contexts/ReportIdContext";
 import "../css/custom.css";
 
@@ -9,10 +10,13 @@ const CitationFootnote = () => {
   const location = useLocation();
   const pathname = location.pathname; // docId
   const reportId = useReportId ? useReportId() : null;
+  const docsBase = useBaseUrl("docs/");
+  const bibsBase = useBaseUrl("bibliographies/");
+  const countersBase = useBaseUrl("counters/");
 
-  const reportPath = pathname.replace(/^\/RMC-Software-Documentation\/docs\//, "/RMC-Software-Documentation/bibliographies/").replace(/\/[^/]*$/, "");
+  const reportPath = pathname.replace(docsBase, bibsBase).replace(/\/[^/]*$/, "");
   const bibFilePath = `${reportPath}/bib.json`;
-  const countersFilePath = reportId ? `/RMC-Software-Documentation/counters/${reportId}.json` : null;
+  const countersFilePath = reportId ? `${countersBase}${reportId}.json` : null;
 
   // Subscribe to per-page used keys (for filtering to only those used here)
   const usedKeys = useUsedCitations(pathname);

--- a/src/components/Equation.js
+++ b/src/components/Equation.js
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import 'katex/dist/katex.min.css';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { BlockMath, InlineMath } from 'react-katex';
@@ -10,10 +11,11 @@ const Equation = ({ equationKey, equation, inline = false, id }) => {
   const reportId = useReportId();
   const equationId = id || equationKey;
   const mathRef = useRef(null);
+  const countersBase = useBaseUrl('counters/');
 
   useEffect(() => {
     if (!reportId) return;
-    const jsonPath = `/RMC-Software-Documentation/counters/${reportId}.json`;
+    const jsonPath = `${countersBase}${reportId}.json`;
     (async () => {
       try {
         const res = await fetch(jsonPath);
@@ -26,7 +28,7 @@ const Equation = ({ equationKey, equation, inline = false, id }) => {
         console.error('Error loading counters:', e);
       }
     })();
-  }, [reportId, equationKey]);
+  }, [reportId, equationKey, countersBase]);
 
   const scaleEquation = useCallback(() => {
     const wrapper = mathRef.current;

--- a/src/components/EquationReference.js
+++ b/src/components/EquationReference.js
@@ -1,19 +1,19 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useEffect, useMemo, useState } from 'react';
 import { useReportId } from '../contexts/ReportIdContext';
 import '../css/custom.css';
-
-const STATIC_BASE = '/RMC-Software-Documentation';
-const DOCS_ROUTE_BASE = '/RMC-Software-Documentation/docs';
 
 const toDocSlug = (docId = '') => docId.replace(/\.mdx$/i, '').replace(/^\d{1,3}-/, '');
 
 const EquationReference = ({ equationKey }) => {
   const [equationInfo, setEquationInfo] = useState(null);
   const reportId = useReportId();
+  const countersBase = useBaseUrl('counters/');
+  const docsRouteBase = useBaseUrl('docs');
 
   useEffect(() => {
     if (!reportId) return;
-    const jsonPath = `${STATIC_BASE}/counters/${reportId}.json`;
+    const jsonPath = `${countersBase}${reportId}.json`;
     (async () => {
       try {
         const res = await fetch(jsonPath);
@@ -26,7 +26,7 @@ const EquationReference = ({ equationKey }) => {
         console.error('Error loading counters:', e);
       }
     })();
-  }, [reportId, equationKey]);
+  }, [reportId, equationKey, countersBase]);
 
   const targetId = equationKey;
 
@@ -34,8 +34,8 @@ const EquationReference = ({ equationKey }) => {
 
   const targetDocPath = useMemo(() => {
     if (!equationInfo?.parentDocPath || !docSlug) return '';
-    return `${DOCS_ROUTE_BASE}/${equationInfo.parentDocPath}/${docSlug}`;
-  }, [equationInfo?.parentDocPath, docSlug]);
+    return `${docsRouteBase}/${equationInfo.parentDocPath}/${docSlug}`;
+  }, [equationInfo?.parentDocPath, docSlug, docsRouteBase]);
 
   const isSamePage = useMemo(() => {
     const normalize = (p) => (p?.endsWith('/') ? p.slice(0, -1) : p || '');

--- a/src/components/Figure.js
+++ b/src/components/Figure.js
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useEffect, useState } from 'react';
 import { useReportId } from '../contexts/ReportIdContext'; // Import the context hook to retrieve the reportId
 import imageDimensions from '../imageDimensions';
@@ -6,6 +7,8 @@ import '../css/custom.css';
 const Figure = ({ figKey, src, alt, caption, width = '80%', background = 'filled', id }) => {
   const [figInfo, setFigInfo] = useState(null);
   const reportId = useReportId(); // Get the reportId from the context
+  const imgUrl = useBaseUrl(src);
+  const countersBase = useBaseUrl('counters/');
 
   // If id is not passed, fall back to figKey
   const figureId = id || figKey;
@@ -17,7 +20,7 @@ const Figure = ({ figKey, src, alt, caption, width = '80%', background = 'filled
   useEffect(() => {
     if (!reportId) return; // If reportId is not available, don't fetch
 
-    const jsonPath = `/RMC-Software-Documentation/counters/${reportId}.json`; // Use reportId to determine the path
+    const jsonPath = `${countersBase}${reportId}.json`;
 
     const loadCounters = async () => {
       try {
@@ -43,13 +46,13 @@ const Figure = ({ figKey, src, alt, caption, width = '80%', background = 'filled
     };
 
     loadCounters();
-  }, [reportId, figKey]);
+  }, [reportId, figKey, countersBase]);
 
   const imgBgClass = background === 'transparent' ? '' : 'bg-surface-page dark:bg-white';
 
   return (
     <figure id={figureId} className="my-[1em] ml-0 mr-auto w-full justify-items-start border-y border-border-color py-5">
-      <img src={`/RMC-Software-Documentation/${src}`} alt={alt} className={`block h-auto ${imgBgClass}`} style={{ maxWidth: width }} width={dims?.width} height={dims?.height} />
+      <img src={imgUrl} alt={alt} className={`block h-auto ${imgBgClass}`} style={{ maxWidth: width }} width={dims?.width} height={dims?.height} />
       <figcaption className="mt-[1em] max-w-full text-left font-usace text-caption italic text-gray-500 dark:text-gray-400">
         {figInfo ? `Figure ${figInfo.figNumber}` : 'Figure'}: {caption}
       </figcaption>

--- a/src/components/FigureInline.js
+++ b/src/components/FigureInline.js
@@ -1,8 +1,9 @@
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import React from "react";
 import "../css/custom.css";
 
 const FigureInline = ({ src }) => {
-  const imgSrc = `/RMC-Software-Documentation/${src}`;
+  const imgSrc = useBaseUrl(src);
 
   return <img src={imgSrc} className="inline-block !h-[1em] !w-auto align-middle" />;
 };

--- a/src/components/FigureNoRef.js
+++ b/src/components/FigureNoRef.js
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import imageDimensions from '../imageDimensions';
 import '../css/custom.css';
 
@@ -6,11 +7,12 @@ const FigureNoRef = ({ src, alt, width = '80%', background = 'filled' }) => {
 
   const normalizedSrc = src.replace(/^\//, '');
   const dims = imageDimensions[normalizedSrc];
+  const imgUrl = useBaseUrl(src);
 
   return (
     <figure className="my-[1em] ml-0 mr-auto w-full justify-items-start border-y border-border-color py-5">
       <img
-        src={`/RMC-Software-Documentation/${src}`}
+        src={imgUrl}
         alt={alt}
         className={`block h-auto ${imgBgClass}`}
         style={{ maxWidth: width }}

--- a/src/components/FigureReference.js
+++ b/src/components/FigureReference.js
@@ -1,9 +1,7 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useReportId } from '../contexts/ReportIdContext';
 import '../css/custom.css';
-
-const STATIC_BASE = '/RMC-Software-Documentation'; // for /static assets like /counters
-const DOCS_ROUTE_BASE = '/RMC-Software-Documentation/docs'; // for doc pages
 
 // strip ".mdx" and any leading "digits-" prefix (e.g., "05-schmertmann" -> "schmertmann")
 const toDocSlug = (docId = '') => docId.replace(/\.mdx$/i, '').replace(/^\d{1,3}-/, '');
@@ -17,10 +15,13 @@ const FigReference = ({ figKey, suffix }) => {
   const reportId = useReportId();
   const showTimer = useRef(null);
   const hideTimer = useRef(null);
+  const countersBase = useBaseUrl('counters/');
+  const staticBase = useBaseUrl('/');
+  const docsRouteBase = useBaseUrl('docs');
 
   useEffect(() => {
     if (!reportId) return;
-    const jsonPath = `${STATIC_BASE}/counters/${reportId}.json`;
+    const jsonPath = `${countersBase}${reportId}.json`;
     (async () => {
       try {
         const res = await fetch(jsonPath);
@@ -33,7 +34,7 @@ const FigReference = ({ figKey, suffix }) => {
         console.error('Error loading counters:', e);
       }
     })();
-  }, [reportId, figKey]);
+  }, [reportId, figKey, countersBase]);
 
   const targetId = figKey;
 
@@ -41,8 +42,8 @@ const FigReference = ({ figKey, suffix }) => {
 
   const targetDocPath = useMemo(() => {
     if (!figInfo?.parentDocPath || !docSlug) return '';
-    return `${DOCS_ROUTE_BASE}/${figInfo.parentDocPath}/${docSlug}`;
-  }, [figInfo?.parentDocPath, docSlug]);
+    return `${docsRouteBase}/${figInfo.parentDocPath}/${docSlug}`;
+  }, [figInfo?.parentDocPath, docSlug, docsRouteBase]);
 
   const isSamePage = useMemo(() => {
     const normalize = (p) => (p?.endsWith('/') ? p.slice(0, -1) : p || '');
@@ -75,7 +76,7 @@ const FigReference = ({ figKey, suffix }) => {
 
   if (!figInfo) return <span className="font-usace text-normal whitespace-nowrap">Figure</span>;
 
-  const imgSrc = figInfo.src ? `${STATIC_BASE}/${figInfo.src}` : '';
+  const imgSrc = figInfo.src ? `${staticBase}${figInfo.src.replace(/^\//, '')}` : '';
 
   return (
     <span className="relative inline whitespace-nowrap" onMouseEnter={handleEnter} onMouseLeave={handleLeave}>

--- a/src/components/TableHorizontal.js
+++ b/src/components/TableHorizontal.js
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useEffect, useState } from 'react';
 import { useReportId } from '../contexts/ReportIdContext';
 import '../css/custom.css';
@@ -21,10 +22,11 @@ const TableHorizontal = ({
   const [tableInfo, setTableInfo] = useState(null);
   const reportId = useReportId();
   const tableId = id || tableKey;
+  const countersBase = useBaseUrl('counters/');
 
   useEffect(() => {
     if (!reportId) return;
-    const jsonPath = `/RMC-Software-Documentation/counters/${reportId}.json`;
+    const jsonPath = `${countersBase}${reportId}.json`;
     (async () => {
       try {
         const response = await fetch(jsonPath);
@@ -37,7 +39,7 @@ const TableHorizontal = ({
         console.error('Error loading counters:', error);
       }
     })();
-  }, [reportId, tableKey]);
+  }, [reportId, tableKey, countersBase]);
 
   const renderHTML = (content) => ({ __html: content });
 

--- a/src/components/TableReference.js
+++ b/src/components/TableReference.js
@@ -1,9 +1,7 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useEffect, useMemo, useState } from 'react';
 import { useReportId } from '../contexts/ReportIdContext';
 import '../css/custom.css';
-
-const STATIC_BASE = '/RMC-Software-Documentation'; // for /static assets like /counters
-const DOCS_ROUTE_BASE = '/RMC-Software-Documentation/docs'; // for doc pages
 
 // strip ".mdx" and any leading "digits-" prefix (e.g., "05-schmertmann" -> "schmertmann")
 const toDocSlug = (docId = '') => docId.replace(/\.mdx$/i, '').replace(/^\d{1,3}-/, '');
@@ -11,10 +9,12 @@ const toDocSlug = (docId = '') => docId.replace(/\.mdx$/i, '').replace(/^\d{1,3}
 const TableReference = ({ tableKey }) => {
   const [tableInfo, setTableInfo] = useState(null);
   const reportId = useReportId();
+  const countersBase = useBaseUrl('counters/');
+  const docsRouteBase = useBaseUrl('docs');
 
   useEffect(() => {
     if (!reportId) return;
-    const jsonPath = `${STATIC_BASE}/counters/${reportId}.json`;
+    const jsonPath = `${countersBase}${reportId}.json`;
     (async () => {
       try {
         const res = await fetch(jsonPath);
@@ -27,7 +27,7 @@ const TableReference = ({ tableKey }) => {
         console.error('Error loading counters:', e);
       }
     })();
-  }, [reportId, tableKey]);
+  }, [reportId, tableKey, countersBase]);
 
   const targetId = tableKey;
 
@@ -35,8 +35,8 @@ const TableReference = ({ tableKey }) => {
 
   const targetDocPath = useMemo(() => {
     if (!tableInfo?.parentDocPath || !docSlug) return '';
-    return `${DOCS_ROUTE_BASE}/${tableInfo.parentDocPath}/${docSlug}`;
-  }, [tableInfo?.parentDocPath, docSlug]);
+    return `${docsRouteBase}/${tableInfo.parentDocPath}/${docSlug}`;
+  }, [tableInfo?.parentDocPath, docSlug, docsRouteBase]);
 
   const isSamePage = useMemo(() => {
     const normalize = (p) => (p?.endsWith('/') ? p.slice(0, -1) : p || '');

--- a/src/components/TableVertical.js
+++ b/src/components/TableVertical.js
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useEffect, useState } from 'react';
 import { useReportId } from '../contexts/ReportIdContext';
 import '../css/custom.css';
@@ -21,10 +22,11 @@ const TableVertical = ({
   const [tableInfo, setTableInfo] = useState(null);
   const reportId = useReportId();
   const tableId = id || tableKey;
+  const countersBase = useBaseUrl('counters/');
 
   useEffect(() => {
     if (!reportId) return;
-    const jsonPath = `/RMC-Software-Documentation/counters/${reportId}.json`;
+    const jsonPath = `${countersBase}${reportId}.json`;
     (async () => {
       try {
         const response = await fetch(jsonPath);
@@ -37,7 +39,7 @@ const TableVertical = ({
         console.error('Error loading counters:', error);
       }
     })();
-  }, [reportId, tableKey]);
+  }, [reportId, tableKey, countersBase]);
 
   const renderHTML = (content) => ({ __html: content });
 

--- a/src/components/VersionSelector.js
+++ b/src/components/VersionSelector.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from "react";
 import { useHistory, useLocation } from "@docusaurus/router";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import "../css/custom.css";
 
 const VersionSelector = ({ document }) => {
   const history = useHistory();
   const location = useLocation();
+  const versionListUrl = useBaseUrl("versions/versionList.json");
 
   const [versions, setVersions] = useState([]);
   const [selectedVersion, setSelectedVersion] = useState("");
@@ -18,7 +20,7 @@ const VersionSelector = ({ document }) => {
   useEffect(() => {
     const fetchVersions = async () => {
       try {
-        const response = await fetch("/RMC-Software-Documentation/versions/versionList.json");
+        const response = await fetch(versionListUrl);
         const data = await response.json();
         const versionList = data[document] || [];
 
@@ -34,7 +36,7 @@ const VersionSelector = ({ document }) => {
     };
 
     fetchVersions();
-  }, [document, location.pathname]);
+  }, [document, location.pathname, versionListUrl]);
 
   const handleVersionChange = async (event) => {
     const newVersion = event.target.value;

--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useEffect, useState } from 'react';
 import { useReportId } from '../contexts/ReportIdContext';
 import '../css/custom.css';
@@ -23,13 +24,17 @@ const Video = ({
 }) => {
   const [videoInfo, setVideoInfo] = useState(null);
   const reportId = useReportId();
+  const countersBase = useBaseUrl('counters/');
+  const assetsBase = useBaseUrl('/');
 
   const figureId = id || videoKey;
+
+  const resolveAsset = (p) => (p ? `${assetsBase}${String(p).replace(/^\//, '')}` : undefined);
 
   useEffect(() => {
     if (!reportId) return;
 
-    const jsonPath = `/RMC-Software-Documentation/counters/${reportId}.json`;
+    const jsonPath = `${countersBase}${reportId}.json`;
 
     const loadCounters = async () => {
       try {
@@ -53,7 +58,7 @@ const Video = ({
     };
 
     loadCounters();
-  }, [reportId, videoKey]);
+  }, [reportId, videoKey, countersBase]);
 
   if (!videoInfo) return <span>Loading...</span>;
 
@@ -70,7 +75,7 @@ const Video = ({
       <video
         className="block h-auto"
         style={{ maxWidth: width }}
-        poster={poster ? `/RMC-Software-Documentation/${poster}` : undefined}
+        poster={resolveAsset(poster)}
         autoPlay={resolvedAutoPlay}
         loop={resolvedLoop}
         controls={resolvedControls}
@@ -80,12 +85,12 @@ const Video = ({
       >
         {sources.length > 0
           ? sources.map((s, i) => (
-              <source key={i} src={`/RMC-Software-Documentation/${s.src}`} type={s.type} />
+              <source key={i} src={resolveAsset(s.src)} type={s.type} />
             ))
-          : src && <source src={`/RMC-Software-Documentation/${src}`} />}
+          : src && <source src={resolveAsset(src)} />}
         {trackSrc && (
           <track
-            src={`/RMC-Software-Documentation/${trackSrc}`}
+            src={resolveAsset(trackSrc)}
             kind="captions"
             srcLang={trackLang}
             label={trackLabel}

--- a/src/components/VideoReference.js
+++ b/src/components/VideoReference.js
@@ -1,3 +1,4 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useEffect, useState } from 'react';
 import { useReportId } from '../contexts/ReportIdContext';
 import '../css/custom.css';
@@ -5,11 +6,12 @@ import '../css/custom.css';
 const VideoReference = ({ videoKey }) => {
   const [videoInfo, setVideoInfo] = useState(null);
   const reportId = useReportId(); // Get the reportId from the context
+  const countersBase = useBaseUrl('counters/');
 
   useEffect(() => {
     if (!reportId) return; // If reportId is not available, don't fetch
 
-    const jsonPath = `/RMC-Software-Documentation/counters/${reportId}.json`; // Use reportId to determine the path
+    const jsonPath = `${countersBase}${reportId}.json`;
 
     const loadCounters = async () => {
       try {
@@ -35,7 +37,7 @@ const VideoReference = ({ videoKey }) => {
     };
 
     loadCounters();
-  }, [videoKey]); // Re-fetch if figKey changes
+  }, [videoKey, countersBase]); // Re-fetch if figKey changes
 
   if (!videoInfo) return <span>Loading...</span>;
 

--- a/src/pages/desktop-applications/lifesim.js
+++ b/src/pages/desktop-applications/lifesim.js
@@ -17,14 +17,15 @@ const lifeSimData = filterByCategoryAndSoftware('desktop-applications', 'lifesim
 export const lifeSimDocs = lifeSimData;
 
 export default function LifeSim() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const lifeSimData = lifeSimDocs.map((doc) => ({
     ...doc,

--- a/src/pages/desktop-applications/rmc-bestfit.js
+++ b/src/pages/desktop-applications/rmc-bestfit.js
@@ -17,14 +17,15 @@ const bestFitData = filterByCategoryAndSoftware('desktop-applications', 'rmc-bes
 export const bestFitDocs = bestFitData;
 
 export default function BestFit() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const bestFitData = bestFitDocs.map((doc) => ({
     ...doc,

--- a/src/pages/desktop-applications/rmc-rfa.js
+++ b/src/pages/desktop-applications/rmc-rfa.js
@@ -17,14 +17,15 @@ const RFAData = filterByCategoryAndSoftware('desktop-applications', 'rmc-rfa').m
 export const RFADocs = RFAData;
 
 export default function RFA() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const RFAData = RFADocs.map((doc) => ({
     ...doc,

--- a/src/pages/desktop-applications/rmc-totalrisk.js
+++ b/src/pages/desktop-applications/rmc-totalrisk.js
@@ -17,14 +17,15 @@ const totalRiskData = filterByCategoryAndSoftware('desktop-applications', 'rmc-t
 export const totalRiskDocs = totalRiskData;
 
 export default function TotalRisk() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const totalRiskData = totalRiskDocs.map((doc) => ({
     ...doc,

--- a/src/pages/dev.js
+++ b/src/pages/dev.js
@@ -14,14 +14,15 @@ import WebAppIcon from '../components/icons/WebAppIcon';
 import '../css/custom.css';
 
 export default function Dev() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const dstVersion = latestVersions['dev/dst/database-schema'] || 'v1.0';
 

--- a/src/pages/toolboxes/internal-erosion-suite.js
+++ b/src/pages/toolboxes/internal-erosion-suite.js
@@ -14,14 +14,15 @@ const internalErosionSuite = filterByCategoryAndSoftware('toolboxes', 'internal-
 export const internalErosionSuiteDocs = internalErosionSuite;
 
 export default function InternalErosionSuite() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const internalErosionSuite = internalErosionSuiteDocs.map((doc) => ({
     ...doc,

--- a/src/pages/toolboxes/overtopping-suite.js
+++ b/src/pages/toolboxes/overtopping-suite.js
@@ -14,14 +14,15 @@ const overtoppingSuite = filterByCategoryAndSoftware('toolboxes', 'overtopping-s
 export const overtoppingSuiteDocs = overtoppingSuite;
 
 export default function OvertoppingSuite() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const overtoppingSuite = overtoppingSuiteDocs.map((doc) => ({
     ...doc,

--- a/src/pages/toolboxes/risk-calculations-suite.js
+++ b/src/pages/toolboxes/risk-calculations-suite.js
@@ -14,14 +14,15 @@ const riskCalculationsSuite = filterByCategoryAndSoftware('toolboxes', 'risk-cal
 export const riskCalculationsSuiteDocs = riskCalculationsSuite;
 
 export default function RiskCalculationsSuite() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const riskCalculationsSuite = riskCalculationsSuiteDocs.map((doc) => ({
     ...doc,

--- a/src/pages/toolboxes/seismic-hazard-suite.js
+++ b/src/pages/toolboxes/seismic-hazard-suite.js
@@ -14,14 +14,15 @@ const seismicHazardSuite = filterByCategoryAndSoftware('toolboxes', 'seismic-haz
 export const seismicHazardSuiteDocs = seismicHazardSuite;
 
 export default function SeismicHazardSuite() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const seismicHazardSuite = seismicHazardSuiteDocs.map((doc) => ({
     ...doc,

--- a/src/pages/toolboxes/spillway-erosion-suite.js
+++ b/src/pages/toolboxes/spillway-erosion-suite.js
@@ -26,14 +26,15 @@ const spillwayErosionSuite = [
 export const spillwayErosionSuiteDocs = spillwayErosionSuite;
 
 export default function SpillwayErosionSuite() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const spillwayErosionSuite = spillwayErosionSuiteDocs.map((doc) => ({
     ...doc,

--- a/src/pages/web-applications/dst.js
+++ b/src/pages/web-applications/dst.js
@@ -14,14 +14,15 @@ const dstData = filterByCategoryAndSoftware('web-applications', 'dst').map((doc)
 export const dstDocs = dstData;
 
 export default function DST() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const dstData = dstDocs.map((doc) => ({
     ...doc,

--- a/src/pages/web-applications/lst.js
+++ b/src/pages/web-applications/lst.js
@@ -14,14 +14,15 @@ const lstData = filterByCategoryAndSoftware('web-applications', 'lst').map((doc)
 export const lstDocs = lstData;
 
 export default function LST() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const lstData = lstDocs.map((doc) => ({
     ...doc,

--- a/src/pages/web-applications/rrft.js
+++ b/src/pages/web-applications/rrft.js
@@ -14,14 +14,15 @@ const rrftData = filterByCategoryAndSoftware('web-applications', 'rrft').map((do
 export const rrftDocs = rrftData;
 
 export default function RRFT() {
+  const latestVersionsUrl = addBaseUrl('versions/latestVersions.json');
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
-    fetch('/RMC-Software-Documentation/versions/latestVersions.json')
+    fetch(latestVersionsUrl)
       .then((response) => response.json())
       .then((data) => setLatestVersions(data))
       .catch((error) => console.error('Error loading latest versions:', error));
-  }, []);
+  }, [latestVersionsUrl]);
 
   const rrftData = rrftDocs.map((doc) => ({
     ...doc,

--- a/src/theme/Layout/useLatestVersions.js
+++ b/src/theme/Layout/useLatestVersions.js
@@ -1,11 +1,14 @@
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import { useEffect, useState } from "react";
 
-export default function useLatestVersions(jsonPath = "/RMC-Software-Documentation/versions/latestVersions.json") {
+export default function useLatestVersions(jsonPath) {
+  const defaultJsonPath = useBaseUrl("versions/latestVersions.json");
+  const url = jsonPath || defaultJsonPath;
   const [latestVersions, setLatestVersions] = useState({});
 
   useEffect(() => {
     let mounted = true;
-    fetch(jsonPath)
+    fetch(url)
       .then((r) => r.json())
       .then((data) => {
         if (mounted) setLatestVersions(data || {});
@@ -14,7 +17,7 @@ export default function useLatestVersions(jsonPath = "/RMC-Software-Documentatio
     return () => {
       mounted = false;
     };
-  }, [jsonPath]);
+  }, [url]);
 
   return latestVersions;
 }


### PR DESCRIPTION
## Summary
- Replaced hardcoded `/RMC-Software-Documentation/` paths in 15 components, 13 landing pages, and the analytics client module with `useBaseUrl()` (React) and `siteConfig.baseUrl` from `@generated/docusaurus.config` (client module).
- PR preview builds now resolve figure/video sources, counter JSON, version metadata, and bibliography paths against the active baseUrl (`/RMC-Software-Documentation-Previews/pr-N/`) instead of the production prefix — fixing broken figures, missing caption numbers, and unresolved figure/table/equation/citation references on previews.
- Verified with both a default production build and a preview-style build (`DOCUSAURUS_BASE_URL=/RMC-Software-Documentation-Previews/pr-test/`); the built HTML emits correctly-prefixed asset URLs in both environments.