### PR TITLE
Gave users a direct link to download external OpenStreetMap data for LifeSim's road network input

### DIFF
--- a/docs/desktop-applications/lifesim/users-guide/v1.0/08-road-network-data.mdx
+++ b/docs/desktop-applications/lifesim/users-guide/v1.0/08-road-network-data.mdx
@@ -206,10 +206,14 @@ To view and/or edit the default CFCC road attributes:
 
 ## Create Road Network Datasets
 
-Road network datasets can be created by importing information from a polyline shapefile that represents a road network. Another way to import a road
-network dataset is using a bounding polygon shapefile to generate a road network using all available data within the bounding polygon from the
-OpenStreetMap <Citation citationKey="OSM"/> database (refer to [Appendix
-C](./19-appendix-editing-road-network-data-for-use-in-lifesim.mdx) for further information).
+Road network datasets can be created by importing information from a polyline shapefile that represents a road network. 
+Primary OpenStreetMap data for North America is 
+available <a href="https://download.geofabrik.de/north-america.html" target="_blank" rel="noopener noreferrer">here</a>.
+
+Another way to import a road
+network dataset is directly in LifeSim using a bounding polygon shapefile to generate a road network using all available data within the bounding polygon from the
+OpenStreetMap <Citation citationKey="OSM"/> database. Refer to [Appendix
+C](./19-appendix-editing-road-network-data-for-use-in-lifesim.mdx) for further information.
 
 ### Import from a Shapefile
 


### PR DESCRIPTION
## Description

Added sentence "Primary OpenStreetMap data for North America is available here [with hyperlink]" to help alleviate users from searching for road network data download link. 

## Affected documents

LifeSim User's Guide

## Related issue(s)

No issues. Editorial addition.

## Pre-submission checklist

- [x] I have previewed these changes locally or via the PR preview URL
- [x] My branch name uses one of the expected prefixes: `docs/new/`, `docs/major/`, `docs/minor/`, or `docs/fix/`
- [x] I have updated `00-version-history.mdx` if this change warrants a version entry
It does not.
- [ ] I have assigned a specific peer reviewer via the Reviewers sidebar (if known)

## Technical edit (Lanes 1, 2, and 3)

- [ ] Technical edit comments addressed — ready for Director review

## Notes for reviewers

No necessary really necessary except Adam. Added only one sentence. 
