### PR TITLE
Updated mentions of LifeSim version 2.1.6(a) download to version 2.2

### DIFF
--- a/docs/desktop-applications/lifesim/users-guide/v1.0/03-installing-and-starting-lifesim.mdx
+++ b/docs/desktop-applications/lifesim/users-guide/v1.0/03-installing-and-starting-lifesim.mdx
@@ -33,9 +33,9 @@ editing, and viewing output results.
 
 ## Installation
 
-<Button href="https://github.com/USACE-RMC/LifeSim/releases/download/v2.1.6a/LifeSim_2.1.6a.7z"><u>🡇</u> LifeSim v2.1.6a</Button>
+<Button href="https://github.com/USACE-RMC/LifeSim/releases/download/v2.2/LifeSim_2.2.7z"><u>🡇</u> LifeSim v2.2</Button>
 
-LifeSim Version 2.1.6a is available for download as a self-extracting setup package.
+LifeSim Version 2.2 is available for download as a self-extracting setup package.
 
 The installer (with administrative privileges) will run through selecting an install location (e.g., *C:\Program Files*).
 
@@ -88,10 +88,10 @@ In the *Study Tree* (<FigReference figKey="figure-1"/>), right-click **New Study
 Either way, the **Save As** browser will open (<FigReference figKey="figure-4"/>). From the **Save As** browser, navigate to the location (directory) where the 
 LifeSim study will be created. Enter a project name (required) in the **File name** box.
 
-Example: *ProjectName_LifeSimVersion_YYYY* (e.g., *xyzDam_RiskAssessment_LifeSim216a_2026*) where,
+Example: *ProjectName_LifeSimVersion_YYYY* (e.g., *xyzDam_RiskAssessment_LifeSim22_2026*) where,
 
 - Date format is YYYY, the year of the project creation.
-- LifeSimVersion is the version of LifeSim used to create or update the project (e.g., *LifeSim216a* for LifeSim Version 2.1.6a).
+- LifeSimVersion is the version of LifeSim used to create or update the project (e.g., *LifeSim22* for LifeSim Version 2.2).
 
 Click **Save**, and the **Save** **As** browser will close. The LifeSim main window will now have the name of the study in the 
 *Study Tree* and the *Title Bar* (<FigReference figKey="figure-1"/>).
@@ -139,7 +139,7 @@ references to the LifeSim study elements. The <em>*.fia</em> file also holds the
 
 ## Opening an Existing Study
 
-It is important to note that at this time, LifeSim Version 2.1.6a cannot open or update LifeSim Version 1.0 studies. 
+It is important to note that at this time, LifeSim Version 2.2 cannot open or update LifeSim Version 1.0 studies. 
 
 To open an existing LifeSim study:
 

--- a/docs/desktop-applications/lifesim/users-guide/v1.0/04-lifesim-interface.mdx
+++ b/docs/desktop-applications/lifesim/users-guide/v1.0/04-lifesim-interface.mdx
@@ -42,7 +42,7 @@ The main window is organized with a *Title Bar*, a *Menu Bar*, two tabs (**Study
 Layers**), a *Map Window* (with an associated toolbar), and the *Status Bar*. The following describes basic
 elements of the main window:
 
-**Title Bar**: Displays the Version number (Version 2.1.6), for Version 2.0 and above, and the name of the active LifeSim study.
+**Title Bar**: Displays the Version number (such as Version 2.1.6 in <FigReference figKey="figure-7"/>), for Version 2.0 and above, and the name of the active LifeSim study.
 
 **Menu Bar**: Contains the LifeSim menus.
 


### PR DESCRIPTION
## Description

Woody released LifeSim version 2.2. Updated mentions of version 2.1.6(a) to 2.2.

## Affected documents

LifeSim User's Guide only currently.

## Related issue(s)

<!-- Link related issues. Use "Closes #N" to auto-close on merge. -->

## Pre-submission checklist

- [x] I have previewed these changes locally or via the PR preview URL
- [x] My branch name uses one of the expected prefixes: `docs/new/`, `docs/major/`, `docs/minor/`, or `docs/fix/`
- [x] I have updated `00-version-history.mdx` if this change warrants a version entry
None needed.
- [x] I have assigned a specific peer reviewer via the Reviewers sidebar (if known)
None needed.

## Technical edit (Lanes 1, 2, and 3)

- [ ] Technical edit comments addressed — ready for Director review

## Notes for reviewers

<!-- Anything reviewers should know. -->
